### PR TITLE
Change to use insertText instead of label

### DIFF
--- a/rplugin/python3/deoplete/source/lsp.py
+++ b/rplugin/python3/deoplete/source/lsp.py
@@ -84,9 +84,16 @@ class Source(Base):
         else:
             items = results
         for rec in items:
+            if len(rec.get('insertText', '')) !=0:
+                if rec.get('insertTextFormat', 0) != 1:
+                    word = rec.get('entryName', rec.get('label'))
+                else:
+                    word = rec['insertText']
+            else:
+                word = rec.get('entryName', rec.get('label'))
+
             item = {
-                'word': re.sub(r'\([^)]*\)', '',
-                               rec.get('entryName', rec.get('label'))),
+                'word': re.sub(r'\([^)]*\)', '', word),
                 'abbr': rec['label'],
                 'dup': 0,
             }


### PR DESCRIPTION
Since the label of the return value of clangd contains a space, `insertText` is used instead. If we follow the [Language Server Protocol Specification](https://microsoft.github.io/language-server-protocol/specification), we may want to use `textEdit` if it exists. But I have not found a server that still returns `textEdit`.