### PR TITLE
Improve user_data

### DIFF
--- a/rplugin/python3/deoplete/source/lsp.py
+++ b/rplugin/python3/deoplete/source/lsp.py
@@ -101,6 +101,11 @@ class Source(Base):
                 'word': word,
                 'abbr': rec['label'],
                 'dup': 0,
+                'user_data': json.dumps({
+                    'deoplete_lsp': {
+                        'item': rec
+                    }
+                })
             }
 
             if 'kind' in rec:
@@ -115,11 +120,7 @@ class Source(Base):
                 item['info'] = rec['documentation']['value']
 
             if 'insertTextFormat' in rec and rec['insertTextFormat'] == 2:
-                item['user_data'] = json.dumps({
-                    'snippet': word,
-                    'snippet_trigger': word
-                })
-                item['kind'] = 'snippet'
+                item['kind'] = 'Snippet'
 
             candidates.append(item)
 

--- a/rplugin/python3/deoplete/source/lsp.py
+++ b/rplugin/python3/deoplete/source/lsp.py
@@ -102,9 +102,7 @@ class Source(Base):
                 'abbr': rec['label'],
                 'dup': 0,
                 'user_data': json.dumps({
-                    'deoplete_lsp': {
-                        'item': rec
-                    }
+                    'lspitem': rec
                 })
             }
 


### PR DESCRIPTION
I think, user_data should be `CompletionItem` instead of `snippet/snippet_trigger` for future improvements.


### 1. LSP spec has `completionItem/resolve`
- The `completionItem/resolve` needs full `CompletionItem`.

### 2. LSP spec has `textEdit`, `additionalTextEdits` or `Snippet`.
- Currently implementation supports snippet only.
- If we provide full `CompletionItem`, other plugins can expand textEdits, additionalTextEdits.
    - For example, typescript-language-server returns `additionalTextEdits` for auto-importing.

Related:
#15 
https://github.com/hrsh7th/vim-vsnip-integ/pull/4