### PR TITLE
Fix TypeError in Source.process_candidates and minor tidy-ups

### DIFF
--- a/rplugin/python3/deoplete/source/lsp.py
+++ b/rplugin/python3/deoplete/source/lsp.py
@@ -3,10 +3,9 @@
 # AUTHOR: Shougo Matsushita <Shougo.Matsu at gmail.com>
 # =============================================================================
 
-import re
 import json
-
 from deoplete.source.base import Base
+
 
 LSP_KINDS = [
     'Text',
@@ -106,18 +105,18 @@ class Source(Base):
                 })
             }
 
-            if 'kind' in rec:
+            if isinstance(rec.get('kind'), int):
                 item['kind'] = LSP_KINDS[rec['kind'] - 1]
 
-            if 'detail' in rec and rec['detail']:
+            if rec.get('detail'):
                 item['menu'] = rec['detail']
 
-            if 'documentation' in rec and isinstance(rec['documentation'], str):
+            if isinstance(rec.get('documentation'), str):
                 item['info'] = rec['documentation']
-            elif 'documentation' in rec and isinstance(rec['documentation'], dict) and 'value' in rec['documentation']:
+            elif isinstance(rec.get('documentation'), dict) and 'value' in rec['documentation']:
                 item['info'] = rec['documentation']['value']
 
-            if 'insertTextFormat' in rec and rec['insertTextFormat'] == 2:
+            if rec.get('insertTextFormat') == 2:
                 item['kind'] = 'Snippet'
 
             candidates.append(item)


### PR DESCRIPTION
https://github.com/Shougo/deoplete-lsp/blob/ca4018c69aca115033f3e3b5408331e76ff64cd0/rplugin/python3/deoplete/source/lsp.py#L109-L110

Here, `rec['kind']` can be `None`, resulting in `TypeError`:

![TypeError](https://user-images.githubusercontent.com/11627708/71400217-610ec180-2669-11ea-9a37-7d575dbbb971.png)
