### PR TITLE
Check if textEdit is None

### DIFF
--- a/rplugin/python3/deoplete/source/lsp.py
+++ b/rplugin/python3/deoplete/source/lsp.py
@@ -88,7 +88,7 @@ class Source(Base):
         else:
             items = results
         for rec in items:
-            if 'textEdit' in rec:
+            if 'textEdit' in rec and rec['textEdit'] is not None:
                 word = rec['textEdit']['newText']
             elif rec.get('insertText', ''):
                 if rec.get('insertTextFormat', 1) != 1:


### PR DESCRIPTION
According to the PHPLS spec, the `textEdit` field on the `CompletionItem` interface is nullable.  An error occurs when servers that don't support Text Edits return a null value for the `textEdit` field during completion:
```
[deoplete] Traceback (most recent call last):
    File "deoplete.nvim/rplugin/python3/deoplete/child.py", line 194, in _gather_results
        result = self._get_result(context, source)
    File "deoplete.nvim/rplugin/python3/deoplete/child.py", line 254, in _get_result
        ctx['candidates'] = source.gather_candidates(ctx)
    File "deoplete-lsp/rplugin/python3/deoplete/source/lsp.py", line 61, in gather_candidates
        return self.process_candidates()
    File "deoplete-lsp/rplugin/python3/deoplete/source/lsp.py", line 92, in process_candidates
        word = rec['textEdit']['newText']
    TypeError: 'NoneType' object is not subscriptable
        Error from lsp: 'NoneType' object is not subscriptable.  Use :messages / see above for error details.
```
The bug was introduced with ff0ce9a1d0651b60c.