### PR TITLE
Slight fixes for textDocument/hover

### DIFF
--- a/lua/hover.lua
+++ b/lua/hover.lua
@@ -52,7 +52,7 @@ local create_window = function(method, result)
 
     hover_buffer, hover_window = util.fancy_floating_markdown(markdown_lines, {
       pad_left = 1; pad_right = 1;
-      col = complete_display_info['col']; width = complete_display_info['width']; row = 0;
+      col = complete_display_info['col']; width = complete_display_info['width']; row = vim.fn.winline();
       align = alignment;
     })
 

--- a/plugin/deoplete/lsp.vim
+++ b/plugin/deoplete/lsp.vim
@@ -13,3 +13,7 @@ let g:loaded_deoplete_lsp = 1
 if get(g:, 'deoplete#enable_at_startup', 0)
   call deoplete#lsp#enable()
 endif
+
+let g:completion_docked_hover = get(g:, 'completion_docked_hover', 0)
+let g:completion_docked_maximum_size = get(g:, 'completion_docked_maximum_size', 10)
+let g:completion_docked_minimum_size = get(g:, 'completion_docked_minimum_size', 3)


### PR DESCRIPTION
Fixes for #23.

* c7443db Without this, it shows the hover window at the top of the editor. This fixes it.
* f0a549f Without this, the values are nil and it raises errors. This fixes it.