### PR TITLE
Hotfix rust generic brackets

### DIFF
--- a/rplugin/python3/deoplete/source/lsp.py
+++ b/rplugin/python3/deoplete/source/lsp.py
@@ -115,7 +115,7 @@ class Source(Base):
 
             # Remove parentheses from word.
             # Note: some LSP includes snippet parentheses in word(newText)
-            word = re.sub(r'\(.*\)(\$\d+)?', '', word)
+            word = re.sub(r'[\(|<].*[\)|>](\$\d+)?', '', word)
 
             item = {
                 'word': word,


### PR DESCRIPTION
In Rust, brackets`<>` used in generics are not entered during completion.

Before
<img width="273" alt="スクリーンショット 2020-08-25 7 47 05" src="https://user-images.githubusercontent.com/3197942/91105091-20f55800-e6aa-11ea-8a2e-14e81fba5d55.png">

After
<img width="232" alt="スクリーンショット 2020-08-25 8 09 09" src="https://user-images.githubusercontent.com/3197942/91105155-4aae7f00-e6aa-11ea-9a37-378d03c877c3.png">
