### PR TITLE
Fix ignore duplicates

### DIFF
--- a/rplugin/python3/deoplete/source/lsp.py
+++ b/rplugin/python3/deoplete/source/lsp.py
@@ -120,7 +120,7 @@ class Source(Base):
             item = {
                 'word': word,
                 'abbr': rec['label'],
-                'dup': 1,
+                'dup': 0,
                 'user_data': json.dumps({
                     'lspitem': rec
                 })


### PR DESCRIPTION
Improved the situation where duplicate LSP candidates are displayed.

Before
<img width="522" alt="スクリーンショット 2020-08-25 20 20 35" src="https://user-images.githubusercontent.com/3197942/91169598-98f76880-e712-11ea-9c2e-bfe9c598b3b5.png">

After
<img width="512" alt="スクリーンショット 2020-08-25 20 33 20" src="https://user-images.githubusercontent.com/3197942/91169615-9f85e000-e712-11ea-82d1-35ae80a3092f.png">
