### PR TITLE
Remove word replacement processing

### DIFF
--- a/rplugin/python3/deoplete/source/lsp.py
+++ b/rplugin/python3/deoplete/source/lsp.py
@@ -113,10 +113,6 @@ class Source(Base):
             else:
                 word = rec.get('entryName', rec.get('label'))
 
-            # Remove parentheses from word.
-            # Note: some LSP includes snippet parentheses in word(newText)
-            word = re.sub(r'[\(|<].*[\)|>](\$\d+)?', '', word)
-
             item = {
                 'word': word,
                 'abbr': rec['label'],


### PR DESCRIPTION
The process of removing unnecessary character strings is possible
by setting nvim-lsp.

For example, set the following in lsp.lua.
```
local capabilities = {
    textDocument = {
        completion = {
            completionItem = {
                snippetSupport = false
            }
        }
    }
};

require'nvim_lsp'.rust_analyzer.setup { capabilities = capabilities }
```