### PR TITLE
Bug fix.  The hover timer was not stopping correctly when leaving insert mode

### DIFF
--- a/lua/hover.lua
+++ b/lua/hover.lua
@@ -151,7 +151,7 @@ local insert_enter_handler = function()
 end
 
 local insert_leave_handler = function()
-  hover = hover_initialise
+  hover.insert_mode = false
 end
 
 return {


### PR DESCRIPTION
The timer was never stopping previously, and this caused issues.  I first noticed it because it caused the `CursorHold` event to never be fired, since the timer was being executed constantly