### PR TITLE
Check result type

### DIFF
--- a/lua/candidates.lua
+++ b/lua/candidates.lua
@@ -7,7 +7,7 @@
 local api = vim.api
 
 local get_candidates = function(_, _, result)
-  local success = (result and not vim.tbl_isempty(result)) and true or false
+  local success = (type(result) == 'table' and not vim.tbl_isempty(result)) and true or false
   api.nvim_set_var('deoplete#source#lsp#_results', result)
   api.nvim_set_var('deoplete#source#lsp#_success', success)
   api.nvim_set_var('deoplete#source#lsp#_requested', true)


### PR DESCRIPTION
This PR will fix the issue of https://github.com/Shougo/deoplete-lsp/issues/37

I investigate the issue then I found the reason.

Until https://github.com/neovim/neovim/commit/6312792d8a6a7d293661d33d440343d4cc6e0e6e#diff-c6a4160a416b22cd1fd833b8f852c4fbaf1f25adf75053e82a1025aa2c607ac9R1034, nvim-lsp always callback with `err, method, result, client_id, bufnr` but nvim sometimes callback with `err, method, bufnr` after the commit.